### PR TITLE
Document root cause and fix approach for source chooser label bug

### DIFF
--- a/docs/stories/BUG-006-source-chooser-label-uses-folder-name.md
+++ b/docs/stories/BUG-006-source-chooser-label-uses-folder-name.md
@@ -18,13 +18,33 @@ As a user selecting a source, I want the list label to match the source note nam
 ## Context
 Observed behavior: add-new-deck flow displays `Clippings` instead of the actual source filename.
 
-Likely this comes from `getParentOrFilename` being reused where filename should be displayed.
+### Root Cause (confirmed 2026-02-16)
+
+**Data flow:** `book-list.tsx` displays `book.name` → set during `AnnotationsNote.initialize()` at `src/data/models/AnnotationsNote.ts:319` → calls `getParentOrFilename(this.path)` from `src/infrastructure/disk.ts:107-112`.
+
+**The problem:** `getParentOrFilename` returns `tFile.parent?.name || tFile.basename` — it prioritizes the parent folder name over the filename. For a file at `Clippings/constitution.md`, this returns `"Clippings"` instead of `"constitution"`. For MoonReader books where folder = filename (e.g., `BookTitle/BookTitle.md`), the bug is invisible.
+
+**Why it's a separation-of-concerns issue:** `getParentOrFilename` bakes a domain heuristic ("prefer parent folder as book name") into the infrastructure layer. The infrastructure should provide a simple `getBasename(path)` accessor, and the domain decides what the display name should be.
+
+### Approach
+
+1. Add `getBasename(path)` to `src/infrastructure/disk.ts` — wraps `getTFileForPath(path).basename`, platform-agnostic
+2. Replace `getParentOrFilename` calls in `AnnotationsNote.ts:319` and `api.ts:348` with `getBasename`
+3. Delete `getParentOrFilename` (no remaining callers)
+4. Migrate `getParentOrFilename_*` test fixtures to `getBasename_*`
+5. Add regression test with folder ≠ filename case
+
+### Blocker: coupling in api.ts
+
+`api.ts:348` updates `book.name = getParentOrFilename(newPath)` after moving a file to its own folder during deck creation. This name-update logic belongs in the domain model (AnnotationsNote), not the API orchestration layer. Refactoring this call site first would simplify the bug fix and avoid making the API module more coupled.
 
 ## Likely Touchpoints
-- `src/ui/components/book-list.tsx`
-- `src/api.ts` (if display label assembled there)
-- `src/infrastructure/disk.ts` (`getParentOrFilename` call-chain)
-- `tests/deck-landing-page.test.tsx` and/or `tests/api.test.ts`
+- `src/data/models/AnnotationsNote.ts:319` — primary: `this.name` assignment
+- `src/api.ts:348` — secondary: `book.name` update after file move (needs refactoring first)
+- `src/infrastructure/disk.ts:107-112` — `getParentOrFilename` to be replaced with `getBasename`
+- `src/ui/components/book-list.tsx:46` — displays `book.name` (no change needed)
+- `tests/api.clippings.test.ts` — fixture migration
+- `tests/api.test.ts`, `tests/models/annotations.test.ts`, `tests/deck-landing-page.test.tsx`, `tests/routes/import/PersonalNotePage.test.tsx` — fixture list updates
 
 ## Related
 - [DEBT-012](DEBT-012-component-reusability.md)


### PR DESCRIPTION
## Summary
Updated the BUG-006 issue documentation with a confirmed root cause analysis and a detailed fix approach. This is a documentation-only change that clarifies the bug's origin and outlines the refactoring strategy.

## Key Changes
- **Root cause confirmed**: `getParentOrFilename()` in the infrastructure layer prioritizes parent folder names over filenames, causing `Clippings/constitution.md` to display as `"Clippings"` instead of `"constitution"`
- **Separation of concerns issue identified**: Domain heuristics ("prefer parent folder as book name") are baked into the infrastructure layer rather than the domain model
- **Fix approach documented**: 
  - Add `getBasename(path)` accessor to `src/infrastructure/disk.ts`
  - Replace `getParentOrFilename` calls in `AnnotationsNote.ts:319` and `api.ts:348` with `getBasename`
  - Delete the now-unused `getParentOrFilename` function
  - Update test fixtures and add regression test for folder ≠ filename case
- **Blocker identified**: `api.ts:348` has coupling that should be refactored first—name-update logic after file moves belongs in the domain model, not the API orchestration layer

## Notable Details
- Pinpointed exact call sites: `AnnotationsNote.initialize()` at line 319 and API file-move handler at line 348
- Clarified why the bug is invisible for MoonReader books (folder name = filename)
- Listed all affected test files for fixture migration

https://claude.ai/code/session_01UcPnsxf1Eq6XAJemcBioWr